### PR TITLE
rename : fix schema import ts file

### DIFF
--- a/src/db/schema/AlcoholRequests.ts
+++ b/src/db/schema/AlcoholRequests.ts
@@ -2,9 +2,9 @@ import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
 import { users } from './Users.ts'
-import { alcoholStyles } from './AlcoholStyles.ts'
-import { alcoholLocations } from './AlcoholLocations.ts'
-import { alcoholCategories } from './AlcoholCategories.ts'
+import { alcoholStyles } from './AlcoholStyles'
+import { alcoholLocations } from './AlcoholLocations'
+import { alcoholCategories } from './AlcoholCategories'
 
 export const alcoholRequests = sqliteTable('alcohol_requests', {
   id:         integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/AlcoholStyles.ts
+++ b/src/db/schema/AlcoholStyles.ts
@@ -1,6 +1,6 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 
-import { alcoholCategories } from './AlcoholCategories.ts'
+import { alcoholCategories } from './AlcoholCategories'
 
 export const alcoholStyles = sqliteTable('alcohol_styles', {
   id:         integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/Alcohols.ts
+++ b/src/db/schema/Alcohols.ts
@@ -1,10 +1,10 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
-import { users } from './Users.ts'
-import { alcoholCategories } from './AlcoholCategories.ts'
-import { alcoholStyles } from './AlcoholStyles.ts'
-import { alcoholLocations } from './AlcoholLocations.ts'
+import { users } from './Users'
+import { alcoholCategories } from './AlcoholCategories'
+import { alcoholStyles } from './AlcoholStyles'
+import { alcoholLocations } from './AlcoholLocations'
 
 export const alcohols = sqliteTable('alcohols', {
   id:         integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/Comments.ts
+++ b/src/db/schema/Comments.ts
@@ -1,7 +1,7 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
-import { users } from './Users.ts'
+import { users } from './Users'
 
 export const comments = sqliteTable('comments', {
   id:         integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/FlavorKeywords.ts
+++ b/src/db/schema/FlavorKeywords.ts
@@ -1,6 +1,6 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 
-import { flavorCategories } from './FlavorCategories.ts'
+import { flavorCategories } from './FlavorCategories'
 
 export const flavorKeywords = sqliteTable('flavor_keywords', {
   id:         integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/Inquiries.ts
+++ b/src/db/schema/Inquiries.ts
@@ -1,7 +1,7 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
-import { users } from './Users.ts'
+import { users } from './Users'
 
 export const inquiries = sqliteTable('inquiries', {
   id:        integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/Posts.ts
+++ b/src/db/schema/Posts.ts
@@ -1,7 +1,7 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
-import { users } from './Users.ts'
+import { users } from './Users'
 
 export const posts = sqliteTable('posts', {
   id:        integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/Reactions.ts
+++ b/src/db/schema/Reactions.ts
@@ -1,7 +1,7 @@
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
 import { sql }                        from 'drizzle-orm'
 
-import { users } from './Users.js'
+import { users } from './Users'
 
 export const reactions = sqliteTable('reactions', {
   id:           integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/TastingNotes.ts
+++ b/src/db/schema/TastingNotes.ts
@@ -1,8 +1,8 @@
 import { sqliteTable, text, integer, real, blob } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
-import { users } from './Users.ts'
-import { alcohols } from './Alcohols.ts'
+import { users } from './Users'
+import { alcohols } from './Alcohols'
 
 export const tastingNotes = sqliteTable('tasting_notes', {
   id:         integer('id').primaryKey({ autoIncrement: true }),

--- a/src/db/schema/Wishes.ts
+++ b/src/db/schema/Wishes.ts
@@ -1,8 +1,8 @@
 import { sqliteTable, integer } from 'drizzle-orm/sqlite-core'
 import { sql }                  from 'drizzle-orm'
 
-import { users }    from './Users.ts'
-import { alcohols } from './Alcohols.ts'
+import { users }    from './Users'
+import { alcohols } from './Alcohols'
 
 export const wishes = sqliteTable('wishes', {
   id:        integer('id').primaryKey({ autoIncrement: true }),


### PR DESCRIPTION
## #️⃣ Issue Number
- #6 

## 📝 요약(Summary)

초기 테이블 생성 및 예시 데이터 삽입 시 오류 발생
import 시 파일 확장자가 포함되어있어서 발생하는 오류 

## 💬 공유사항 to 리뷰어

schema 폴더의 각 테이블 파일들의 import 부분의 .ts 확장자를 제거하였습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)