### PR TITLE
[FEAT] 테이스팅 노트 작성 시 DB에 없는 술도 가능하도록 추가

### DIFF
--- a/src/db/schema/TastingNotes.ts
+++ b/src/db/schema/TastingNotes.ts
@@ -13,8 +13,9 @@ import { alcohols } from "./Alcohols";
 export const tastingNotes = sqliteTable("tasting_notes", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   alcoholId: integer("alcohol_id")
-    .notNull()
     .references(() => alcohols.id),
+  customAlcoholName: text("custom_alcohol_name", { length: 255 }),
+  customAlcoholCategory: text("custom_alcohol_category", { length: 100 }),
   userId: integer("user_id")
     .notNull()
     .references(() => users.id),

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -42,6 +42,7 @@ async function seed() {
         { name: "소주" },
         { name: "막걸리" },
         { name: "사케" },
+        { name: "기타" },
       ])
       .returning();
 

--- a/src/modules/tastingnote/index.ts
+++ b/src/modules/tastingnote/index.ts
@@ -201,9 +201,15 @@ export const tastingnote = new Elysia({
     }
   })
   .post('/', async ({ body, set, authUser }) => {
-    const newNote = await TastingNote.createNote(authUser.userId, body)
+    const result = await TastingNote.createNote(authUser.userId, body)
+
+    if (!result.success) {
+      set.status = result.status ?? 400
+      return { error: result.error as string }
+    }
+
     set.status = 201
-    return newNote
+    return result
   }, {
     body: TastingNoteModel.CreateTastingNoteRequest,
     detail: {

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -81,7 +81,7 @@ export namespace TastingNoteModel {
         alcoholId: t.Optional(t.Numeric()),
         customAlcohol: t.Optional(t.Object({
             name: t.String({ minLength: 1 }),
-            category: t.Optional(t.String())
+            category: t.String({ minLength: 1 })
         })),
         createdTime: t.Date(),
         aroma_note: RatingMap,

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -58,7 +58,7 @@ export namespace TastingNoteModel {
         noteId: t.Number(),
         noteTitle: t.String(),
         alcoholCategory: t.String(),
-        alcoholName: t.String(),
+        alcoholName: t.String(),  // COALESCE fallback ensures non-null
         noteImage: t.String(),
         writer: t.String(),
         commentNum: t.Number(),
@@ -78,7 +78,11 @@ export namespace TastingNoteModel {
 
     export const CreateTastingNoteRequest = t.Object({
         title: t.String(),
-        alcoholId: t.Numeric(),
+        alcoholId: t.Optional(t.Numeric()),
+        customAlcohol: t.Optional(t.Object({
+            name: t.String({ minLength: 1 }),
+            category: t.Optional(t.String())
+        })),
         createdTime: t.Date(),
         aroma_note: RatingMap,
         palate_note: RatingMap,

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -22,6 +22,8 @@ export namespace TastingNoteModel {
         writerId: t.Number(),
         writerName: t.String(),
         writerImage: t.Nullable(t.String()),
+        alcoholName: t.String(),
+        alcoholCategory: t.String(),
         like: t.Number(),
         unlike: t.Number(),
         viewer: t.Number(),

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -415,6 +415,8 @@ export abstract class TastingNote {
       writerId: note.writerId,
       writerName: note.writerName,
       writerImage: note.writerImage,
+      alcoholName: note.alcoholName,
+      alcoholCategory: note.alcoholCategory,
       like: likeCount,
       unlike: unlikeCount,
       viewer: 0, // TODO : viewer count 구현

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -5,7 +5,19 @@ import { TastingNoteModel } from './model'
 
 export abstract class TastingNote {
   static async createNote(userId: number, body: TastingNoteModel.CreateTastingNoteRequestType) {
-    const { title, alcoholId, createdTime, aroma_note, palate_note, finish_note, images } = body
+    const { title, alcoholId, customAlcohol, createdTime, aroma_note, palate_note, finish_note, images } = body
+
+    if (!alcoholId && !customAlcohol?.name) {
+      return { success: false, error: '술 정보가 필요합니다. alcoholId 또는 customAlcohol.name을 입력해주세요.', status: 400 }
+    }
+
+    const hasNote =
+      Object.keys(aroma_note).length > 0 ||
+      Object.keys(palate_note).length > 0 ||
+      Object.keys(finish_note).length > 0
+    if (!hasNote) {
+      return { success: false, error: '아로마, 팔레트, 피니쉬 중 하나 이상의 노트를 입력해주세요.', status: 400 }
+    }
 
     const createdAt = createdTime
 
@@ -14,7 +26,9 @@ export abstract class TastingNote {
       .values({
         title,
         userId: userId,
-        alcoholId,
+        alcoholId: alcoholId ?? null,
+        customAlcoholName: alcoholId ? null : (customAlcohol?.name ?? null),
+        customAlcoholCategory: alcoholId ? null : (customAlcohol?.category ?? null),
         aromaNote: aroma_note,
         palateNote: palate_note,
         finishNote: finish_note,
@@ -35,19 +49,19 @@ export abstract class TastingNote {
     const conditions = []
 
     if (query) {
-      conditions.push(sql`(${tastingNotes.title} LIKE ${`%${query}%`} OR ${alcohols.name} LIKE ${`%${query}%`})`)
+      conditions.push(sql`(${tastingNotes.title} LIKE ${`%${query}%`} OR ${alcohols.name} LIKE ${`%${query}%`} OR ${tastingNotes.customAlcoholName} LIKE ${`%${query}%`})`)
     }
 
     if (category) {
-      conditions.push(eq(alcoholCategories.name, category))
+      conditions.push(sql`(${alcoholCategories.name} = ${category} OR ${tastingNotes.customAlcoholCategory} = ${category})`)
     }
 
     const baseQuery = db
       .select({
         noteId: tastingNotes.id,
         noteTitle: tastingNotes.title,
-        alcoholCategory: alcoholCategories.name,
-        alcoholName: alcohols.name,
+        alcoholCategory: sql<string>`COALESCE(${alcoholCategories.name}, ${tastingNotes.customAlcoholCategory}, '')`,
+        alcoholName: sql<string>`COALESCE(${alcohols.name}, ${tastingNotes.customAlcoholName}, '')`,
         images: tastingNotes.images,
         writer: users.nickname,
         commentNum: sql<number>`(SELECT count(*) FROM ${comments} WHERE ${comments.targetType} = 'tasting_note' AND ${comments.targetId} = ${tastingNotes.id})`,
@@ -57,8 +71,8 @@ export abstract class TastingNote {
         createdTime: tastingNotes.createdAt,
       })
       .from(tastingNotes)
-      .innerJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
-      .innerJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
+      .leftJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
+      .leftJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
       .innerJoin(users, eq(tastingNotes.userId, users.id))
       .where(and(...conditions))
       .limit(size)
@@ -75,8 +89,8 @@ export abstract class TastingNote {
     const totalCountQuery = await db
       .select({ count: count() })
       .from(tastingNotes)
-      .innerJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
-      .innerJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
+      .leftJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
+      .leftJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
       .where(and(...conditions))
       .get()
 
@@ -108,8 +122,8 @@ export abstract class TastingNote {
       .select({
         noteId: tastingNotes.id,
         noteTitle: tastingNotes.title,
-        alcoholCategory: alcoholCategories.name,
-        alcoholName: alcohols.name,
+        alcoholCategory: sql<string>`COALESCE(${alcoholCategories.name}, ${tastingNotes.customAlcoholCategory}, '')`,
+        alcoholName: sql<string>`COALESCE(${alcohols.name}, ${tastingNotes.customAlcoholName}, '')`,
         images: tastingNotes.images,
         writer: users.nickname,
         commentNum: sql<number>`(SELECT count(*) FROM ${comments} WHERE ${comments.targetType} = 'tasting_note' AND ${comments.targetId} = ${tastingNotes.id})`,
@@ -119,8 +133,8 @@ export abstract class TastingNote {
         createdTime: tastingNotes.createdAt,
       })
       .from(tastingNotes)
-      .innerJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
-      .innerJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
+      .leftJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
+      .leftJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
       .innerJoin(users, eq(tastingNotes.userId, users.id))
       .orderBy(desc(sql`(SELECT count(*) FROM ${reactions} WHERE ${reactions.targetType} = 'tasting_note' AND ${reactions.targetId} = ${tastingNotes.id} AND ${reactions.reactionType} = 'like')`), desc(tastingNotes.createdAt))
       .limit(5)
@@ -142,8 +156,8 @@ export abstract class TastingNote {
       .select({
         noteId: tastingNotes.id,
         noteTitle: tastingNotes.title,
-        alcoholCategory: alcoholCategories.name,
-        alcoholName: alcohols.name,
+        alcoholCategory: sql<string>`COALESCE(${alcoholCategories.name}, ${tastingNotes.customAlcoholCategory}, '')`,
+        alcoholName: sql<string>`COALESCE(${alcohols.name}, ${tastingNotes.customAlcoholName}, '')`,
         images: tastingNotes.images,
         writer: users.nickname,
         commentNum: sql<number>`(SELECT count(*) FROM ${comments} WHERE ${comments.targetType} = 'tasting_note' AND ${comments.targetId} = ${tastingNotes.id})`,
@@ -153,8 +167,8 @@ export abstract class TastingNote {
         createdTime: tastingNotes.createdAt,
       })
       .from(tastingNotes)
-      .innerJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
-      .innerJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
+      .leftJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
+      .leftJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
       .innerJoin(users, eq(tastingNotes.userId, users.id))
       .where(eq(tastingNotes.alcoholId, alcoholId))
       .orderBy(desc(sql`(SELECT count(*) FROM ${reactions} WHERE ${reactions.targetType} = 'tasting_note' AND ${reactions.targetId} = ${tastingNotes.id} AND ${reactions.reactionType} = 'like')`), desc(tastingNotes.createdAt))

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -326,6 +326,8 @@ export abstract class TastingNote {
         writerId: tastingNotes.userId,
         writerName: users.nickname,
         writerImage: users.profileImageUrl,
+        alcoholName: sql<string>`COALESCE(${alcohols.name}, ${tastingNotes.customAlcoholName}, '')`,
+        alcoholCategory: sql<string>`COALESCE(${alcoholCategories.name}, ${tastingNotes.customAlcoholCategory}, '')`,
         createdTime: tastingNotes.createdAt,
         aromaNote: tastingNotes.aromaNote,
         palateNote: tastingNotes.palateNote,
@@ -334,6 +336,8 @@ export abstract class TastingNote {
       })
       .from(tastingNotes)
       .innerJoin(users, eq(tastingNotes.userId, users.id))
+      .leftJoin(alcohols, eq(tastingNotes.alcoholId, alcohols.id))
+      .leftJoin(alcoholCategories, eq(alcohols.categoryId, alcoholCategories.id))
       .where(eq(tastingNotes.id, id))
       .get()
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- ex) - #이슈번호 -->
- #23 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

**1. tastingNotes 스키마 변경 및 테이스팅 노트 등록 API 수정**
- 스키마에 `customAlcoholName`, `customAlcoholCategory` 컬럼 추가
- `alcoholId` nullable로 변경
- `CreateTastingNoteRequest`에 `customAlcohol` 필드 추가

**2. `/api/v1/notes`에 예외 처리 추가**
- `alcoholId`, `customAlcohol` 둘 다 없으면 400 반환
- 노트(aroma/palate/finish) 셋 다 빈 객체면 400 반환

**3. 단일 테이스팅 노트 조회 API 수정**
- 응답에 `alcoholName`, `alcoholCategory` 추가

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
