### PR TITLE
[FEAT] 테이스팅 노트 좋아요 API 추가 및 글/댓글에 필드 추가

### DIFF
--- a/src/db/schema/Reactions.ts
+++ b/src/db/schema/Reactions.ts
@@ -1,22 +1,33 @@
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 
 import { users } from "./Users";
 
-export const reactions = sqliteTable("reactions", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  userId: integer("user_id")
-    .notNull()
-    .references(() => users.id),
-  targetId: integer("target_id").notNull(),
-  targetType: text("target_type", {
-    enum: ["post", "comment", "alcohol", "tasting_note"],
-  }).notNull(),
-  reactionType: text("reaction_type", { enum: ["like", "unlike"] }).notNull(),
-  createdAt: integer("created_at", { mode: "timestamp" })
-    .notNull()
-    .default(sql`(unixepoch())`),
-});
+export const reactions = sqliteTable(
+  "reactions",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id),
+    targetId: integer("target_id").notNull(),
+    targetType: text("target_type", {
+      enum: ["post", "comment", "alcohol", "tasting_note"],
+    }).notNull(),
+    reactionType: text("reaction_type", { enum: ["like", "unlike"] }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => ({
+    uniqUserTargetReaction: uniqueIndex("reactions_user_target_type_unique").on(
+      table.userId,
+      table.targetId,
+      table.targetType,
+      table.reactionType,
+    ),
+  }),
+);
 
 export type Reaction = typeof reactions.$inferSelect; // 조회용
 export type NewReaction = typeof reactions.$inferInsert; // 생성용

--- a/src/db/schema/TastingNotes.ts
+++ b/src/db/schema/TastingNotes.ts
@@ -19,6 +19,7 @@ export const tastingNotes = sqliteTable("tasting_notes", {
     .notNull()
     .references(() => users.id),
   title: text("title", { length: 255 }).notNull(),
+  content: text("content"),
   images: text("images", { mode: "json" })
     .notNull()
     .$type<string[]>()

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -244,6 +244,7 @@ async function seed() {
           userId: user.id,
           alcoholId: createdAlcohols[0]!.id, // 글렌피딕
           title: "글렌피딕 12년 첫 시음",
+          content: "입문용으로 아주 훌륭합니다. 사과향이 일품이네요.",
           aromaNote: { 과일: { 사과: 4, 배: 3 }, 꽃: { 바닐라: 2 } },
           palateNote: { 단맛: { 꿀: 4 }, 스파이시: { 후추: 2 } },
           finishNote: { 길이: { 중간: 3 } },
@@ -255,6 +256,7 @@ async function seed() {
           userId: user.id,
           alcoholId: createdAlcohols[1]!.id, // 맥캘란
           title: "맥캘란 18년 역시 최고",
+          content: "비싼 값을 합니다. 쉐리향의 깊이가 다르네요.",
           aromaNote: { 과일: { 말린과일: 5 }, 오크: { 쉐리: 5 } },
           palateNote: { 바디감: { 묵직함: 4 }, 단맛: { 초콜릿: 3 } },
           finishNote: { 길이: { 김: 5 } },
@@ -266,6 +268,7 @@ async function seed() {
           userId: user.id,
           alcoholId: createdAlcohols[0]!.id, // 글렌피딕
           title: "글렌피딕 데일리로 좋네요",
+          content: "가볍게 즐기기 좋은 위스키입니다.",
           aromaNote: { 과일: { 청사과: 4 } },
           palateNote: { 가벼움: { 깔끔함: 4 } },
           finishNote: { 길이: { 짧음: 2 } },
@@ -277,6 +280,7 @@ async function seed() {
           userId: user.id,
           alcoholId: createdAlcohols[8]!.id, // 조니워커 블루
           title: "조니워커 블루 - 영원한 클래식",
+          content: "말이 필요 없는 최고의 블렌디드 위스키입니다.",
           aromaNote: { 과일: { 오렌지: 4 }, 꽃: { 헤더: 3 }, 오크: { 쉐리: 4 } },
           palateNote: { 단맛: { 꿀: 5, 바닐라: 4 }, 스파이시: { 정향: 2 } },
           finishNote: { 길이: { 김: 5 } },

--- a/src/modules/tastingnote/index.ts
+++ b/src/modules/tastingnote/index.ts
@@ -216,6 +216,9 @@ export const tastingnote = new Elysia({
     detail: {
       summary: 'Toggle tasting note like',
       tags: ['TastingNote']
+    },
+    response: {
+      200: TastingNoteModel.LikeToggleResponse
     }
   })
   .post('/:noteId/comments/:commentId/like', async ({ params: { noteId, commentId }, set, authUser }) => {
@@ -235,6 +238,9 @@ export const tastingnote = new Elysia({
     detail: {
       summary: 'Toggle comment like',
       tags: ['TastingNote']
+    },
+    response: {
+      200: TastingNoteModel.LikeToggleResponse
     }
   })
   .post('/', async ({ body, set, authUser }) => {

--- a/src/modules/tastingnote/index.ts
+++ b/src/modules/tastingnote/index.ts
@@ -200,6 +200,43 @@ export const tastingnote = new Elysia({
       tags: ['TastingNote']
     }
   })
+  .post('/:noteId/like', async ({ params: { noteId }, set, authUser }) => {
+    const result = await TastingNote.toggleNoteLike(noteId, authUser.userId)
+
+    if (!result.success) {
+      set.status = result.status as number
+      return { error: result.error as string }
+    }
+
+    return { liked: result.liked, likeCount: result.likeCount }
+  }, {
+    params: t.Object({
+      noteId: t.Numeric()
+    }),
+    detail: {
+      summary: 'Toggle tasting note like',
+      tags: ['TastingNote']
+    }
+  })
+  .post('/:noteId/comments/:commentId/like', async ({ params: { noteId, commentId }, set, authUser }) => {
+    const result = await TastingNote.toggleCommentLike(noteId, commentId, authUser.userId)
+
+    if (!result.success) {
+      set.status = result.status as number
+      return { error: result.error as string }
+    }
+
+    return { liked: result.liked, likeCount: result.likeCount }
+  }, {
+    params: t.Object({
+      noteId: t.Numeric(),
+      commentId: t.Numeric()
+    }),
+    detail: {
+      summary: 'Toggle comment like',
+      tags: ['TastingNote']
+    }
+  })
   .post('/', async ({ body, set, authUser }) => {
     const newNote = await TastingNote.createNote(authUser.userId, body)
     set.status = 201

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -115,10 +115,16 @@ export namespace TastingNoteModel {
         notes: t.Array(TastingNoteList)
     })
 
+    export const LikeToggleResponse = t.Object({
+        liked: t.Boolean(),
+        likeCount: t.Number()
+    })
+
     export type CreateTastingNoteRequestType = Static<typeof CreateTastingNoteRequest>
     export type UpdateTastingNoteRequestType = Static<typeof UpdateTastingNoteRequest>
     export type CreateCommentRequestType = Static<typeof CreateCommentRequest>
     export type UpdateCommentRequestType = Static<typeof UpdateCommentRequest>
     export type HotTastingNoteListResponseType = Static<typeof HotTastingNoteListResponse>
     export type BestTastingNoteListResponseType = Static<typeof BestTastingNoteListResponse>
+    export type LikeToggleResponseType = Static<typeof LikeToggleResponse>
 }

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -19,6 +19,7 @@ export namespace TastingNoteModel {
     export const TastingNoteResponse = t.Object({
         noteId: t.Number(),
         title: t.String(),
+        content: t.Nullable(t.String()),
         writerId: t.Number(),
         writerName: t.String(),
         writerImage: t.Nullable(t.String()),
@@ -78,6 +79,7 @@ export namespace TastingNoteModel {
 
     export const CreateTastingNoteRequest = t.Object({
         title: t.String(),
+        content: t.Nullable(t.String()),
         alcoholId: t.Numeric(),
         createdTime: t.Date(),
         aroma_note: RatingMap,
@@ -88,6 +90,7 @@ export namespace TastingNoteModel {
 
     export const UpdateTastingNoteRequest = t.Object({
         title: t.String(),
+        content: t.Nullable(t.String()),
         aroma_note: RatingMap,
         palate_note: RatingMap,
         finish_note: RatingMap,

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -8,6 +8,7 @@ export namespace TastingNoteModel {
     export const Comment = t.Object({
         commentId: t.Number(),
         parentId: t.Nullable(t.Number()),
+        writerId: t.Number(),
         writerNickName: t.String(),
         writerImage: t.Nullable(t.String()),
         content: t.String(),

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -19,6 +19,7 @@ export namespace TastingNoteModel {
 
     export const TastingNoteResponse = t.Object({
         noteId: t.Number(),
+        alcoholId: t.Number(),
         title: t.String(),
         content: t.Nullable(t.String()),
         writerId: t.Number(),

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -329,12 +329,16 @@ export abstract class TastingNote {
     if (existing) {
       await db.delete(reactions).where(eq(reactions.id, existing.id)).run()
     } else {
-      await db.insert(reactions).values({
-        userId,
-        targetId: noteId,
-        targetType: 'tasting_note',
-        reactionType: 'like'
-      }).run()
+      await db
+        .insert(reactions)
+        .values({
+          userId,
+          targetId: noteId,
+          targetType: 'tasting_note',
+          reactionType: 'like'
+        })
+        .onConflictDoNothing()
+        .run()
     }
 
     const likeCountRow = await db
@@ -387,12 +391,16 @@ export abstract class TastingNote {
     if (existing) {
       await db.delete(reactions).where(eq(reactions.id, existing.id)).run()
     } else {
-      await db.insert(reactions).values({
-        userId,
-        targetId: commentId,
-        targetType: 'comment',
-        reactionType: 'like'
-      }).run()
+      await db
+        .insert(reactions)
+        .values({
+          userId,
+          targetId: commentId,
+          targetType: 'comment',
+          reactionType: 'like'
+        })
+        .onConflictDoNothing()
+        .run()
     }
 
     const likeCountRow = await db

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -5,7 +5,7 @@ import { TastingNoteModel } from './model'
 
 export abstract class TastingNote {
   static async createNote(userId: number, body: TastingNoteModel.CreateTastingNoteRequestType) {
-    const { title, alcoholId, createdTime, aroma_note, palate_note, finish_note, images } = body
+    const { title, content, alcoholId, createdTime, aroma_note, palate_note, finish_note, images } = body
 
     const createdAt = createdTime
 
@@ -13,6 +13,7 @@ export abstract class TastingNote {
       .insert(tastingNotes)
       .values({
         title,
+        content,
         userId: userId,
         alcoholId,
         aromaNote: aroma_note,
@@ -173,7 +174,7 @@ export abstract class TastingNote {
   }
 
   static async updateNote(id: number, userId: number, body: TastingNoteModel.UpdateTastingNoteRequestType) {
-    const { title, aroma_note, palate_note, finish_note, images } = body
+    const { title, content, aroma_note, palate_note, finish_note, images } = body
 
     const note = await db.select().from(tastingNotes).where(eq(tastingNotes.id, id)).get()
 
@@ -189,6 +190,7 @@ export abstract class TastingNote {
       .update(tastingNotes)
       .set({
         title,
+        content,
         aromaNote: aroma_note,
         palateNote: palate_note,
         finishNote: finish_note,
@@ -309,6 +311,7 @@ export abstract class TastingNote {
       .select({
         noteId: tastingNotes.id,
         title: tastingNotes.title,
+        content: tastingNotes.content,
         writerId: tastingNotes.userId,
         writerName: users.nickname,
         writerImage: users.profileImageUrl,
@@ -394,6 +397,7 @@ export abstract class TastingNote {
     return {
       noteId: note.noteId,
       title: note.title,
+      content: note.content,
       writerId: note.writerId,
       writerName: note.writerName,
       writerImage: note.writerImage,

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -418,6 +418,7 @@ export abstract class TastingNote {
     const note = await db
       .select({
         noteId: tastingNotes.id,
+        alcoholId: tastingNotes.alcoholId,
         title: tastingNotes.title,
         content: tastingNotes.content,
         writerId: tastingNotes.userId,
@@ -505,6 +506,7 @@ export abstract class TastingNote {
 
     return {
       noteId: note.noteId,
+      alcoholId: note.alcoholId,
       title: note.title,
       content: note.content,
       writerId: note.writerId,

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -461,6 +461,7 @@ export abstract class TastingNote {
       .select({
         commentId: comments.id,
         parentId: comments.parentId,
+        writerId: comments.userId,
         writerNickName: users.nickname,
         writerImage: users.profileImageUrl,
         content: comments.body,

--- a/src/modules/tastingnote/service.ts
+++ b/src/modules/tastingnote/service.ts
@@ -306,6 +306,114 @@ export abstract class TastingNote {
     return { success: true, id: commentId }
   }
 
+  static async toggleNoteLike(noteId: number, userId: number) {
+    const note = await db.select().from(tastingNotes).where(eq(tastingNotes.id, noteId)).get()
+
+    if (!note) {
+      return { success: false, error: '존재하지 않는 테이스팅 노트입니다.', status: 404 }
+    }
+
+    const existing = await db
+      .select()
+      .from(reactions)
+      .where(
+        and(
+          eq(reactions.userId, userId),
+          eq(reactions.targetId, noteId),
+          eq(reactions.targetType, 'tasting_note'),
+          eq(reactions.reactionType, 'like')
+        )
+      )
+      .get()
+
+    if (existing) {
+      await db.delete(reactions).where(eq(reactions.id, existing.id)).run()
+    } else {
+      await db.insert(reactions).values({
+        userId,
+        targetId: noteId,
+        targetType: 'tasting_note',
+        reactionType: 'like'
+      }).run()
+    }
+
+    const likeCountRow = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(reactions)
+      .where(
+        and(
+          eq(reactions.targetId, noteId),
+          eq(reactions.targetType, 'tasting_note'),
+          eq(reactions.reactionType, 'like')
+        )
+      )
+      .get()
+
+    return {
+      success: true,
+      liked: !existing,
+      likeCount: likeCountRow?.count || 0
+    }
+  }
+
+  static async toggleCommentLike(noteId: number, commentId: number, userId: number) {
+    const comment = await db.select().from(comments).where(eq(comments.id, commentId)).get()
+
+    if (!comment) {
+      return { success: false, error: '존재하지 않는 댓글입니다.', status: 404 }
+    }
+
+    if (comment.targetId !== noteId || comment.targetType !== 'tasting_note') {
+      return { success: false, error: '잘못된 요청입니다.', status: 400 }
+    }
+
+    if (comment.deletedAt) {
+      return { success: false, error: '삭제된 댓글입니다.', status: 400 }
+    }
+
+    const existing = await db
+      .select()
+      .from(reactions)
+      .where(
+        and(
+          eq(reactions.userId, userId),
+          eq(reactions.targetId, commentId),
+          eq(reactions.targetType, 'comment'),
+          eq(reactions.reactionType, 'like')
+        )
+      )
+      .get()
+
+    if (existing) {
+      await db.delete(reactions).where(eq(reactions.id, existing.id)).run()
+    } else {
+      await db.insert(reactions).values({
+        userId,
+        targetId: commentId,
+        targetType: 'comment',
+        reactionType: 'like'
+      }).run()
+    }
+
+    const likeCountRow = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(reactions)
+      .where(
+        and(
+          eq(reactions.targetId, commentId),
+          eq(reactions.targetType, 'comment'),
+          eq(reactions.reactionType, 'like')
+        )
+      )
+      .get()
+
+    return {
+      success: true,
+      liked: !existing,
+      likeCount: likeCountRow?.count || 0
+    }
+  }
+
   static async getNoteById(id: number) {
     const note = await db
       .select({


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- ex) - #이슈번호 -->

- #21 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

**1. 테이스팅 노트 좋아요 토글 API 추가** 
- `POST /api/v1/notes/:noteId/like` : 테이스팅 노트 좋아요 토글
- `POST /api/v1/notes/:noteId/comments/:commentId/like` : 댓글 좋아요 토글                                                                                       
- `reactions` 테이블에 unique index를 적용해 중복 좋아요 방지 (DB 레벨에서 보장)
- 응답으로 현재 liked 상태와 likeCount 반환

2. 테이스팅 노트 content 필드 추가                                                                                                                             
- `TastingNotes` 스키마에 `content` 컬럼 추가 (nullable)
- 단일 노트 조회(`GET /api/v1/notes/:noteId`) 응답에 `content` 포함

3. 단일 테이스팅 노트 조회 응답 수정                                                                                                                           
- 응답에 `alcoholId`, `content` 추가                                                                                                                               
- 댓글 응답에 `writerId` 추가                                                                                                                                    

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 좋아요 중복 방지는 DB의 unique index로 처리했습니다. (`userId`, `targetId`, `targetType`, `reactionType` 조합)                                                       

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
