### PR TITLE
[FIX] custom alcohol 테이스팅 노트 조회 불가 버그 수정

### DIFF
--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -289,6 +289,35 @@ async function seed() {
           createdAt: new Date(),
           updatedAt: new Date(),
         },
+        // custom alcohol 노트 — alcoholId 없이 직접 입력
+        {
+          userId: user.id,
+          alcoholId: null,
+          customAlcoholName: "동동주",
+          customAlcoholCategory: "전통주",
+          title: "동네 양조장 동동주",
+          content: "시장 골목 양조장에서 사온 동동주. DB에 없는 술이지만 맛은 최고.",
+          aromaNote: { 곡물: { 쌀: 4 }, 과일: { 복숭아: 2 } },
+          palateNote: { 단맛: { 꿀: 3 }, 산미: { 새콤함: 3 } },
+          finishNote: { 길이: { 짧음: 2 } },
+          images: [],
+          createdAt: new Date(Date.now() - 3600000),
+          updatedAt: new Date(Date.now() - 3600000),
+        },
+        {
+          userId: user.id,
+          alcoholId: null,
+          customAlcoholName: "자가양조 흑맥주",
+          customAlcoholCategory: "맥주",
+          title: "직접 담근 홈브루 흑맥주",
+          content: "홈브루잉으로 만들어봤는데 생각보다 훨씬 맛있다.",
+          aromaNote: { 곡물: { 맥아: 5 }, 기타: { 커피: 3, 초콜릿: 2 } },
+          palateNote: { 바디감: { 묵직함: 4 }, 쓴맛: { 홉: 3 } },
+          finishNote: { 길이: { 중간: 3 } },
+          images: [],
+          createdAt: new Date(Date.now() - 7200000),
+          updatedAt: new Date(Date.now() - 7200000),
+        },
       ])
       .returning();
     console.log("✅ Created", notes.length, "tasting notes");

--- a/src/modules/tastingnote/model.ts
+++ b/src/modules/tastingnote/model.ts
@@ -19,7 +19,7 @@ export namespace TastingNoteModel {
 
     export const TastingNoteResponse = t.Object({
         noteId: t.Number(),
-        alcoholId: t.Number(),
+        alcoholId: t.Nullable(t.Number()),
         title: t.String(),
         content: t.Nullable(t.String()),
         writerId: t.Number(),

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,6 +6,7 @@ import { authGuard } from "../src/modules/auth/middleware";
 import { user } from "../src/modules/user";
 import { wish } from "../src/modules/wish";
 import { alcohol } from "../src/modules/alcohol";
+import { tastingnote } from "../src/modules/tastingnote";
 import { config } from "../src/utils/env";
 
 // 테스트용 앱 생성
@@ -27,7 +28,7 @@ export const createTestApp = () => {
       }),
     )
     .group("/api/v1", (app) =>
-      app.use(auth).use(authGuard).use(user).use(wish).use(alcohol),
+      app.use(auth).use(authGuard).use(user).use(wish).use(alcohol).use(tastingnote),
     );
 };
 

--- a/test/tastingnote.test.ts
+++ b/test/tastingnote.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test, beforeAll, mock } from "bun:test";
+import { createTestApp, createTestToken } from "./setup";
+import type { Elysia } from "elysia";
+
+const BASE_NOTE = {
+  noteId: 1,
+  title: "테스트 노트",
+  content: "테스트 내용",
+  writerId: 1,
+  writerName: "테스터",
+  writerImage: null,
+  alcoholName: "글렌피딕 12년",
+  alcoholCategory: "위스키",
+  like: 0,
+  unlike: 0,
+  viewer: 0,
+  createdTime: new Date().toISOString(),
+  aroma_note: {},
+  palate_note: {},
+  finish_note: {},
+  images: [],
+  comments: [],
+};
+
+describe("TastingNote API", () => {
+  let app: Elysia;
+  let validToken: string;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    validToken = await createTestToken(app, 1);
+  });
+
+  // ===== 테이스팅 노트 단건 조회 =====
+
+  describe("GET /api/v1/notes/:noteId", () => {
+    test("일반 alcohol 노트를 조회할 수 있다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          getNoteById: mock(async () => ({ ...BASE_NOTE, alcoholId: 42 })),
+          incrementViewCount: mock(async () => {}),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes/1", {
+          headers: { Cookie: `accessToken=${validToken}` },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.alcoholId).toBe(42);
+      expect(body.alcoholName).toBe("글렌피딕 12년");
+    });
+
+    test("custom alcohol 노트(alcoholId가 null)를 조회할 수 있다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          getNoteById: mock(async () => ({
+            ...BASE_NOTE,
+            alcoholId: null,          // custom alcohol: DB에 null로 저장됨
+            alcoholName: "직접입력술",
+            alcoholCategory: "기타",
+          })),
+          incrementViewCount: mock(async () => {}),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes/2", {
+          headers: { Cookie: `accessToken=${validToken}` },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.alcoholId).toBeNull();
+      expect(body.alcoholName).toBe("직접입력술");
+      expect(body.alcoholCategory).toBe("기타");
+    });
+
+    test("존재하지 않는 노트 조회 시 404를 반환한다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          getNoteById: mock(async () => null),
+          incrementViewCount: mock(async () => {}),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes/9999", {
+          headers: { Cookie: `accessToken=${validToken}` },
+        }),
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  // ===== 테이스팅 노트 목록 조회 =====
+
+  describe("GET /api/v1/notes", () => {
+    const listResponse = {
+      notes: [
+        {
+          noteId: 1,
+          noteTitle: "테스트 노트",
+          alcoholCategory: "위스키",
+          alcoholName: "글렌피딕 12년",
+          noteImage: "",
+          writer: "테스터",
+          commentNum: 0,
+          like: 0,
+          unlike: 0,
+          viewer: 0,
+          createdTime: new Date().toISOString(),
+        },
+      ],
+      pageUtil: {
+        currentPage: 1,
+        totalPages: 1,
+        totalCount: 1,
+        pageSize: 10,
+        hasNext: false,
+        hasPrevious: false,
+      },
+    };
+
+    test("노트 목록을 조회할 수 있다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          getNotes: mock(async () => listResponse),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes", {
+          headers: { Cookie: `accessToken=${validToken}` },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notes).toHaveLength(1);
+    });
+
+    test("custom alcohol 노트도 목록에 포함된다", async () => {
+      const customNoteList = {
+        ...listResponse,
+        notes: [
+          {
+            ...listResponse.notes[0],
+            alcoholName: "직접입력술",
+            alcoholCategory: "기타",
+          },
+        ],
+      };
+
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          getNotes: mock(async () => customNoteList),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes", {
+          headers: { Cookie: `accessToken=${validToken}` },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.notes[0].alcoholName).toBe("직접입력술");
+    });
+  });
+
+  // ===== 테이스팅 노트 작성 =====
+
+  describe("POST /api/v1/notes", () => {
+    const baseBody = {
+      title: "새 노트",
+      content: null,
+      createdTime: new Date().toISOString(),
+      aroma_note: { 과일: { 사과: 3 } },
+      palate_note: {},
+      finish_note: {},
+      images: [],
+    };
+
+    test("alcoholId로 노트를 작성할 수 있다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          createNote: mock(async () => ({ success: true, id: 1 })),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `accessToken=${validToken}`,
+          },
+          body: JSON.stringify({ ...baseBody, alcoholId: 42 }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+    });
+
+    test("customAlcohol로 노트를 작성할 수 있다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          createNote: mock(async () => ({ success: true, id: 2 })),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `accessToken=${validToken}`,
+          },
+          body: JSON.stringify({
+            ...baseBody,
+            customAlcohol: { name: "직접입력술", category: "기타" },
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+    });
+
+    test("인증 없이 작성 시 401을 반환한다", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...baseBody, alcoholId: 1 }),
+        }),
+      );
+
+      expect(response.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## #️⃣ Issue Number

<!-- ex) - #이슈번호 -->
- #30 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Custom alcohol로 작성된 테이스팅 노트가 조회되지 않는 버그를 수정했습니다.
  
Custom alcohol 노트는 DB에 `alcoholId = null`로 저장되는데, `TastingNoteResponse` 응답 스키마에서 `alcoholId`가 `t.Number()` (non-nullable)로 정의되어 있어 Elysia의 스키마 검증 단계에서 응답이 차단되고 있었습니다.
`t.Nullable(t.Number())`로 변경하여 수정했습니다.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 시드에 custom alcohol 노트 2개(동동주, 자가양조 흑맥주)를 추가했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
