### PR TITLE
[FIX] 비로그인 사용자 조회 API 접근 허용

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,15 @@ const app = new Elysia()
           }),
         )
         .use(auth)
-        .use((app) => authGuard(app))
         // 테스트용 API(인증 미들웨어 확인)
-        .get("/me", ({ authUser }) => {
-          return {
-            message: "OK",
-            userId: authUser.userId,
-          };
-        })
+        .guard({}, (app) =>
+          app.use(authGuard).get("/me", ({ authUser }) => {
+            return {
+              message: "OK",
+              userId: authUser.userId,
+            };
+          }),
+        )
         .use(alcohol)
         .use(user)
         .use(wish)

--- a/src/modules/user/index.ts
+++ b/src/modules/user/index.ts
@@ -1,4 +1,5 @@
 import { Elysia } from "elysia";
+import { authGuard } from "../auth/middleware";
 import { User } from "./service";
 import {
   userProfile,
@@ -13,6 +14,26 @@ import {
 export const user = new Elysia({
   prefix: "/users",
 })
+  // ===== 특정 사용자 정보 조회 (공개) =====
+
+  // 특정 사용자 정보 조회
+  .get(
+    "/:userId",
+    async ({ params }: any) => {
+      return await User.getPublicProfile(params.userId);
+    },
+    {
+      params: userIdParam,
+      response: {
+        200: publicProfile,
+      },
+      detail: {
+        summary: "특정 사용자 정보 조회 API",
+        tags: ["User"],
+      },
+    },
+  )
+  .use(authGuard)
   // ===== 내 정보 관리 =====
 
   // 내 정보 조회
@@ -84,26 +105,6 @@ export const user = new Elysia({
       detail: {
         summary: "내 커뮤니티 글 리스트 조회 API",
         tags: ["User", "Post"],
-      },
-    },
-  )
-
-  // ===== 특정 사용자 정보 조회 =====
-
-  // 특정 사용자 정보 조회
-  .get(
-    "/:userId",
-    async ({ params }: any) => {
-      return await User.getPublicProfile(params.userId);
-    },
-    {
-      params: userIdParam,
-      response: {
-        200: publicProfile,
-      },
-      detail: {
-        summary: "특정 사용자 정보 조회 API",
-        tags: ["User"],
       },
     },
   );

--- a/src/modules/wish/index.ts
+++ b/src/modules/wish/index.ts
@@ -1,11 +1,35 @@
 // modules/wish/index.ts
 import { Elysia, t } from "elysia";
+import { authGuard } from "../auth/middleware";
 import { Wish } from "./service";
 import { wishListRequest, wishListResponse } from "./model";
 
 export const wish = new Elysia({
   prefix: "/wishes",
 })
+  // ===== 특정 사용자 위시 조회 (공개) =====
+
+  // 특정 사용자 위시리스트 조회
+  .get(
+    "/wishes/:userId",
+    async ({ params, query }: any) => {
+      return await Wish.getUserWishList(params.userId, query);
+    },
+    {
+      params: t.Object({
+        userId: t.Numeric({ minimum: 1 }),
+      }),
+      query: wishListRequest,
+      response: {
+        200: wishListResponse,
+      },
+      detail: {
+        summary: "특정 사용자 위시리스트 조회 API",
+        tags: ["Wish"],
+      },
+    },
+  )
+  .use(authGuard)
   // ===== 내 위시 관리 =====
 
   // 내 위시리스트 조회
@@ -85,29 +109,6 @@ export const wish = new Elysia({
       }),
       detail: {
         summary: "위시 삭제 API",
-        tags: ["Wish"],
-      },
-    },
-  )
-
-  // ===== 특정 사용자 위시 조회 (공개) =====
-
-  // 특정 사용자 위시리스트 조회
-  .get(
-    "/wishes/:userId",
-    async ({ params, query }: any) => {
-      return await Wish.getUserWishList(params.userId, query);
-    },
-    {
-      params: t.Object({
-        userId: t.Numeric({ minimum: 1 }),
-      }),
-      query: wishListRequest,
-      response: {
-        200: wishListResponse,
-      },
-      detail: {
-        summary: "특정 사용자 위시리스트 조회 API",
         tags: ["Wish"],
       },
     },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,7 +2,6 @@ import { Elysia } from "elysia";
 import { jwt } from "@elysiajs/jwt";
 import { cookie } from "@elysiajs/cookie";
 import { auth } from "../src/modules/auth";
-import { authGuard } from "../src/modules/auth/middleware";
 import { user } from "../src/modules/user";
 import { wish } from "../src/modules/wish";
 import { alcohol } from "../src/modules/alcohol";
@@ -28,7 +27,7 @@ export const createTestApp = () => {
       }),
     )
     .group("/api/v1", (app) =>
-      app.use(auth).use(authGuard).use(user).use(wish).use(alcohol).use(tastingnote),
+      app.use(auth).use(user).use(wish).use(alcohol).use(tastingnote),
     );
 };
 

--- a/test/tastingnote.test.ts
+++ b/test/tastingnote.test.ts
@@ -145,6 +145,20 @@ describe("TastingNote API", () => {
       expect(body.notes).toHaveLength(1);
     });
 
+    test("로그인하지 않아도 노트 목록을 조회할 수 있다", async () => {
+      mock.module("../src/modules/tastingnote/service", () => ({
+        TastingNote: {
+          getNotes: mock(async () => listResponse),
+        },
+      }));
+
+      const response = await app.handle(
+        new Request("http://localhost/api/v1/notes"),
+      );
+
+      expect(response.status).toBe(200);
+    });
+
     test("custom alcohol 노트도 목록에 포함된다", async () => {
       const customNoteList = {
         ...listResponse,

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -316,11 +316,7 @@ describe("User API", () => {
         }));
 
         const response = await app.handle(
-          new Request("http://localhost/api/v1/users/123", {
-            headers: {
-              Cookie: `accessToken=${validToken}`,
-            },
-          }),
+          new Request("http://localhost/api/v1/users/123"),
         );
 
         expect(response.status).toBe(200);
@@ -349,12 +345,25 @@ describe("User API", () => {
         expect(response.status).toBe(500);
       });
 
-      test("should return 401 without token", async () => {
+      test("should return public profile without token", async () => {
+        mock.module("../src/modules/user/service", () => ({
+          User: {
+            getPublicProfile: mock(async (userId: number) => ({
+              id: userId,
+              nickname: "Public User",
+              profileImageUrl: "https://example.com/public.jpg",
+              wishCnt: 10,
+              noteCnt: 5,
+              createdAt: new Date("2024-01-01"),
+            })),
+          },
+        }));
+
         const response = await app.handle(
           new Request("http://localhost/api/v1/users/123"),
         );
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(200);
       });
     });
   });
@@ -362,12 +371,11 @@ describe("User API", () => {
   // ===== 인증 관련 테스트 =====
 
   describe("Authentication", () => {
-    test("all endpoints should require authentication", async () => {
+    test("my endpoints should require authentication", async () => {
       const endpoints = [
         "/api/v1/users/my",
         "/api/v1/users/my/notes",
         "/api/v1/users/my/posts",
-        "/api/v1/users/123",
       ];
 
       for (const endpoint of endpoints) {

--- a/test/wish.test.ts
+++ b/test/wish.test.ts
@@ -308,11 +308,7 @@ describe("Wish API", () => {
         }));
 
         const response = await app.handle(
-          new Request("http://localhost/api/v1/wishes/wishes/123", {
-            headers: {
-              Cookie: `accessToken=${validToken}`,
-            },
-          }),
+          new Request("http://localhost/api/v1/wishes/wishes/123"),
         );
 
         expect(response.status).toBe(200);
@@ -336,12 +332,12 @@ describe("Wish API", () => {
         expect(response.status).toBe(200);
       });
 
-      test("should return 401 without token", async () => {
+      test("should return user wish list without token", async () => {
         const response = await app.handle(
           new Request("http://localhost/api/v1/wishes/wishes/123"),
         );
 
-        expect(response.status).toBe(401);
+        expect(response.status).toBe(200);
       });
     });
   });
@@ -349,13 +345,12 @@ describe("Wish API", () => {
   // ===== 인증 관련 테스트 =====
 
   describe("Authentication", () => {
-    test("all endpoints should require authentication", async () => {
+    test("my endpoints should require authentication", async () => {
       const endpoints = [
         { method: "GET", url: "/api/v1/wishes/my" },
         { method: "GET", url: "/api/v1/wishes/my/alcohol/123" },
         { method: "POST", url: "/api/v1/wishes/my/alcohol/123" },
         { method: "DELETE", url: "/api/v1/wishes/my/alcohol/123" },
-        { method: "GET", url: "/api/v1/wishes/wishes/123" },
       ];
 
       for (const endpoint of endpoints) {


### PR DESCRIPTION
## #️⃣ Issue Number

- #34

## 📝 요약(Summary)

전역으로 적용되던 `authGuard` 때문에 로그인하지 않은 사용자의 조회 API 요청도 401로 차단되던 문제를 수정했습니다.

공개 조회 라우트는 인증 미들웨어 적용 이전에 등록하고, 사용자별 정보 및 생성·수정·삭제 기능처럼 인증이 필요한 라우트에만 `authGuard`를 적용했습니다.

## 💬 공유사항 to 리뷰어

- 공개 조회 API와 인증 필요 API의 경계가 의도대로 나뉘었는지 확인 부탁드립니다.
  - `/users/:userId`, `/wishes/wishes/:userId`, 테이스팅 노트 및 주류 조회 API는 비로그인 접근 허용
  - `/users/my*`, `/wishes/my*`, 테이스팅 노트 작성·수정·삭제는 인증 유지

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)